### PR TITLE
Shaheer/mpuOffsets

### DIFF
--- a/software/src/main_transmitter.cpp
+++ b/software/src/main_transmitter.cpp
@@ -31,9 +31,13 @@ const byte address[6] = "00001";
 unsigned long int start_time;
 unsigned long int delta_time;
 
+int16_t ax, ay, az, ax_offset, ay_offset, az_offset;
+int16_t gx, gy, gz, gx_offset, gy_offset, gz_offset;
+
 unsigned long int getSeconds();
 void fileInit();
 void writeToFile();
+void calibrateMPU();
 
 void setup() {
     Serial.begin(115200);
@@ -58,10 +62,9 @@ void setup() {
     Serial.println("Done");
 
     pinMode(SD_OFF_PIN, INPUT);
-}
 
-int16_t ax, ay, az;
-int16_t gx, gy, gz;
+    calibrateMPU();
+}
 
 void loop() {
 
@@ -118,7 +121,6 @@ void loop() {
 
     pb_ostream_t stream = pb_ostream_from_buffer(buffer, sizeof(buffer));
     pb_encode(&stream, MyMessage_fields, &msg);
-
     radio.write(buffer, stream.bytes_written);
 
     if (digitalRead(SD_OFF_PIN) == HIGH) {
@@ -135,6 +137,17 @@ void loop() {
     }
 
     delay(100);
+}
+
+void calibrateMPU(){
+
+    mpu.getMotion6(&ax_offset, &ay_offset, &az_offset, &gx_offset, &gy_offset, &gz_offset);
+    Serial.printf("\n*****MPU Recalibrated*****\n");
+
+    if(data_file){
+
+        data_file.println("MPU Recalibrated");
+    }
 }
 
 unsigned long int getSeconds() {

--- a/software/src/main_transmitter.cpp
+++ b/software/src/main_transmitter.cpp
@@ -139,12 +139,12 @@ void loop() {
     delay(100);
 }
 
-void calibrateMPU(){
+void calibrateMPU() {
 
     mpu.getMotion6(&ax_offset, &ay_offset, &az_offset, &gx_offset, &gy_offset, &gz_offset);
     Serial.printf("\n*****MPU Recalibrated*****\n");
 
-    if(data_file){
+    if (data_file) {
 
         data_file.println("MPU Recalibrated");
     }


### PR DESCRIPTION
# MPU Offsets

Added offsets for acceleration and gyroscope values from the MPU module.

## Changes

- Added functions to calculate and apply offset values
- Added button to recalibrate (connected to pin 33)

## Additional Notes

- Recalibrating offsets will print a message to both serial out, and the .csv file recording values

![image](https://github.com/GryphonRacingFSAE/Remote-Logging-Module/assets/113954719/bb64b5b8-18d3-4a8c-8d3e-16e534783c1f)

- Calibration button is the one that is closer to the ESP board (left side of MPU)
- Values are still "noisy" but are generally between +/-100 when at rest